### PR TITLE
Adding option for PHP executable path

### DIFF
--- a/nextcloud-inotifyscan
+++ b/nextcloud-inotifyscan
@@ -40,7 +40,10 @@ def parse_config(config_file):
   """
   try:
     config = configparser.ConfigParser()
-    config.read_file(config_file)
+    try:
+      config.read_file(config_file)
+    except AttributeError:
+      config.readfp(config_file)
   except configparser.Error as e:
     _logger.fatal('config error: %s', e)
   for section in config.sections():

--- a/nextcloud-inotifyscan
+++ b/nextcloud-inotifyscan
@@ -22,7 +22,7 @@ logging.basicConfig(format='%(levelname)s - %(message)s')
 _logger = logging.getLogger()
 
 Instance = collections.namedtuple(
-    'Instance', 'interval occ users external_storage docker')
+    'Instance', 'interval occ users external_storage docker php')
 Folder = collections.namedtuple('Folder', 'occ_cmd path_prefix data_prefix')
 Task = collections.namedtuple('Task', 'occ_cmd paths')
 
@@ -47,6 +47,7 @@ def parse_config(config_file):
     try:
       interval = configparser_default(
           config.getfloat, section, 'interval', 1.0)
+      php = configparser_default(config.get, section, 'php', 'php')
       occ = config.get(section, 'occ')
       users = tuple(map(str.strip, config.get(section, 'user').split(',')))
       external_storage = configparser_default(
@@ -59,7 +60,7 @@ def parse_config(config_file):
           _logger.warning('docker must be specified as `username:container`')
           continue
       yield Instance(interval=interval, occ=occ, users=users,
-                     external_storage=external_storage, docker=docker)
+                     external_storage=external_storage, docker=docker, php=php)
     except configparser.Error as e:
       _logger.warning('config error: %s', e)
 
@@ -140,9 +141,9 @@ def watch_instances(instances):
   for instance in instances:
     if instance.docker:
       occ_cmd = ['docker', 'exec', '-u'+instance.docker[0], instance.docker[1],
-                 'php', instance.occ]
+                 instance.php, instance.occ]
     else:
-      occ_cmd = ['php', instance.occ]
+      occ_cmd = [instance.php, instance.occ]
     data_dir = subprocess.check_output(
         occ_cmd+['config:system:get', 'datadirectory'],
         universal_newlines=True).rstrip()

--- a/nextcloud-inotifyscan
+++ b/nextcloud-inotifyscan
@@ -82,7 +82,8 @@ def parse_environ():
     docker = False
     occ = require_environ('NEXTCLOUD_HOME') + '/occ'
   return Instance(interval=interval, occ=occ, users=(user,),
-                  external_storage=None, docker=docker)
+                  external_storage=None, docker=docker,
+                  php='php')
 
 def parse_args():
   """Parse commandline arguments and yield Instance objects.

--- a/sample.ini
+++ b/sample.ini
@@ -29,3 +29,4 @@ occ = /path/to/nextcloud/occ
 user = cindy
 docker = no
 php = /usr/bin/php8.0
+

--- a/sample.ini
+++ b/sample.ini
@@ -8,7 +8,7 @@ interval = 1
 # sections must be unique; otherwise only the last one will be used.
 [Instance1]
 
-# occ: path to the nextcloud occ script; in docker this is typicall just "occ".
+# occ: path to the nextcloud occ script; in docker this is typically just "occ".
 occ = occ
 
 # user: the nextcloud users to watch changes for; comma separated.
@@ -20,8 +20,12 @@ docker = docker_foo:container_bar
 # external_storage: whether to watch external storages. Defaults to no.
 external_storage = yes
 
+# php: PHP command to use, defaults to "php"
+php = php
+
 [Instance2]
 interval = 0.2
 occ = /path/to/nextcloud/occ
 user = cindy
 docker = no
+php = /usr/bin/php8.0

--- a/tests/mock/bin/php8.0
+++ b/tests/mock/bin/php8.0
@@ -1,0 +1,6 @@
+#!/bin/sh
+if ! print-data-dir $0 $@
+then
+  echo $(basename $0) $@
+fi
+. "$(dirname "$(realpath $0)")"/err

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -139,16 +139,17 @@ interval = 0.1
 occ = ${nextcloud}/occ
 user = bob
 docker = no
+php = php8.0
 EOF
 ${python3} "${inotifyscan}" --config "${tmpconfig}" >${tmp} &
 child=$!
 run-for-bob
 kill-all ${child}
 diff <(cat <<EOF
-php ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/bar --shallow --quiet
-php ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/한국어 --shallow --quiet
-php ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/ --shallow --quiet
-php ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/ --shallow --quiet
+php8.0 ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/bar --shallow --quiet
+php8.0 ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/한국어 --shallow --quiet
+php8.0 ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/ --shallow --quiet
+php8.0 ${nextcloud}/occ files:scan --no-interaction --path=/bob/files/ --shallow --quiet
 EOF
 ) ${tmp} || exit 5
 


### PR DESCRIPTION
Very simple change to add the possibility to select a PHP interpreter. In some cases (like my installation), there are several versions of PHP on the system, and the default one "php" is not necessarily the one used by Nextcloud.