### PR TITLE
fix: remove duplicate slashes in path given to "occ files:scan"

### DIFF
--- a/nextcloud-inotifyscan
+++ b/nextcloud-inotifyscan
@@ -191,7 +191,7 @@ def watch_instances(instances):
       # data_prefix is the actual filesystem folder
       # both should point to the same logical folder
       path_prefix = '/'+user+'/files'
-      data_prefix = data_dir+path_prefix
+      data_prefix = data_dir.rstrip('/')+path_prefix
       folders.append(Folder(occ_cmd=occ_cmd, path_prefix=path_prefix,
                             data_prefix=data_prefix))
     if instance.external_storage:


### PR DESCRIPTION
This caused the full path to be given to "occ files:scan --path" parameter, which is not right and caused failed scans.

Example log:
INFO - watching /var/lib/nextcloud/data//user/files <=> /user/files
INFO - Found /var/lib/nextcloud/data/user/files/tmp/ DELETE bar.txt
INFO - Scan for /var/lib/nextcloud/data/user/files/tmp/