### PR TITLE
Add support for configurable datadirectory for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The script should work if modified for other environments.
 
 ## Features
 
-+ The `data` dir path is now read from `/path/to/nextcloud/config.php` automatically.
++ The `data` dir path is read from Nextcloud config (e.g. `occ config:system:get datadirectory`) automatically. When using Docker, you can override this with the host path via the `datadirectory` config option or the `DATA_DIRECTORY` environment variable.
 + Multiple users and multiple Nextcloud installation instances can be watched in a single service.
 + Local filesystem folders added via the external storage app are supported.
 

--- a/nextcloud-inotifyscan
+++ b/nextcloud-inotifyscan
@@ -23,7 +23,7 @@ logging.basicConfig(format='%(levelname)s - %(message)s')
 _logger = logging.getLogger()
 
 Instance = collections.namedtuple(
-    'Instance', 'interval occ users external_storage docker php')
+    'Instance', 'interval occ users external_storage docker php datadirectory')
 Folder = collections.namedtuple('Folder', 'occ_cmd path_prefix data_prefix')
 Task = collections.namedtuple('Task', 'occ_cmd paths')
 
@@ -95,8 +95,13 @@ def parse_config(config_file):
         if len(docker) != 2:
           _logger.warning('docker must be specified as `username:container`')
           continue
+      datadirectory = configparser_default(
+          config.get, section, 'datadirectory', None)
+      if datadirectory is not None:
+        datadirectory = datadirectory.strip()
       yield Instance(interval=interval, occ=occ, users=users,
-                     external_storage=external_storage, docker=docker, php=php)
+                     external_storage=external_storage, docker=docker, php=php,
+                     datadirectory=datadirectory)
     except configparser.Error as e:
       _logger.warning('config error: %s', e)
 
@@ -117,9 +122,10 @@ def parse_environ():
   else:
     docker = False
     occ = require_environ('NEXTCLOUD_HOME') + '/occ'
+  datadirectory = os.environ.get('DATA_DIRECTORY', '').strip() or None
   return Instance(interval=interval, occ=occ, users=(user,),
                   external_storage=None, docker=docker,
-                  php='php')
+                  php='php', datadirectory=datadirectory)
 
 def parse_args():
   """Parse commandline arguments and yield Instance objects.
@@ -182,10 +188,14 @@ def watch_instances(instances):
     else:
       occ_cmd = [instance.php, instance.occ]
     path_mapper = PathMapper(instance.docker)
-    data_dir = subprocess.check_output(
-        occ_cmd+['config:system:get', 'datadirectory'],
-        universal_newlines=True).rstrip()
-    data_dir = path_mapper(data_dir)
+    if instance.datadirectory:
+      data_dir = instance.datadirectory
+      _logger.info('using configured host datadirectory: %s', data_dir)
+    else:
+      data_dir = subprocess.check_output(
+          occ_cmd+['config:system:get', 'datadirectory'],
+          universal_newlines=True).rstrip()
+      data_dir = path_mapper(data_dir)
     for user in instance.users:
       # path_prefix is the virtual folder recognized by Nextcloud
       # data_prefix is the actual filesystem folder

--- a/sample.ini
+++ b/sample.ini
@@ -17,6 +17,11 @@ user = some_nextcloud_user, alice, bob
 # docker: username:container of the docker, or no.
 docker = docker_foo:container_bar
 
+# datadirectory: (Docker only) host path to the Nextcloud data directory.
+# If set, this is used instead of deriving from occ and container mounts, so
+# the path on the host can differ from the path inside the container.
+# datadirectory = /host/path/to/nextcloud/data
+
 # external_storage: whether to watch external storages. Defaults to no.
 external_storage = yes
 


### PR DESCRIPTION
The data directory on my host is not the same as is inside the container. This PR adds a configurable `datadirectory` for the path on host. If unset it will get from `occ config:system:get datadirectory` as currently is done.